### PR TITLE
fix: load URLs that do not include an extension

### DIFF
--- a/src/allowed-origins.json
+++ b/src/allowed-origins.json
@@ -1,6 +1,8 @@
 [
-    "https://nmrxiv.org",
-    "http://nmrxiv.org",
+    "https://nmrium.nmrxiv.org",
+    "http://nmrium.nmrxiv.org",
+    "http://nmriumdev.nmrxiv.org",
+    "https://nmriumdev.nmrxiv.org",
     "http://localhost",
     "http://localhost:3000",
     "http://127.0.0.1:",

--- a/src/demo/NMRiumWrapperDemo.tsx
+++ b/src/demo/NMRiumWrapperDemo.tsx
@@ -55,6 +55,20 @@ export default function NMRiumWrapperDemo() {
         >
           Test Load from URLS
         </Button.Done>
+
+        <Button.Done
+          style={{ marginRight: '10px' }}
+          onClick={() => {
+            events.trigger('load', {
+              data: [
+                'https://cheminfo.github.io/bruker-data-test/data/zipped/aspirin-1h',
+              ],
+              type: 'url',
+            });
+          }}
+        >
+          Test Load URL without extension
+        </Button.Done>
         <Button.Done
           onClick={async () => {
             const files = await loadFilesFromURLs(['../data/13c.zip']);

--- a/src/hooks/useLoadSpectra.ts
+++ b/src/hooks/useLoadSpectra.ts
@@ -23,12 +23,13 @@ async function loadSpectraFromFiles(files: File[]) {
 async function loadSpectraFromURLs(urls: string[]) {
   const entries = urls.map((url) => {
     const refURL = new URL(url);
-    let name = getFileNameFromURL(url);
+    const name = getFileNameFromURL(url);
+    let path = refURL.pathname;
     const hasExtension = name && name.indexOf('.') !== -1;
     if (!hasExtension) {
-      name = `${name}.zip`;
+      path = `${path}.zip`;
     }
-    return { relativePath: refURL.pathname, baseURL: refURL.origin };
+    return { relativePath: path, baseURL: refURL.origin };
   }, []);
 
   const { data } = await readFromWebSource({ entries });

--- a/test-e2e/core.test.ts
+++ b/test-e2e/core.test.ts
@@ -64,3 +64,13 @@ test('should load NMRium from json', async ({ page }) => {
   // if loaded successfully, there should be a 1H and 13C tabs
   await expect(nmrium.page.locator('.tab-list-item >> text=13C')).toBeVisible();
 });
+test('should load NMRium from URL without .zip extension in the path', async ({
+  page,
+}) => {
+  const nmrium = await NmriumWrapperPage.create(page);
+
+  await nmrium.page.click('text=Test Load URL without extension');
+
+  // if loaded successfully, there should be a 1H
+  await expect(nmrium.page.locator('.tab-list-item >> text=1H')).toBeVisible();
+});


### PR DESCRIPTION
By default append .zip extension if the file URL does not include an extension 